### PR TITLE
Implement extract resources and list files commands ✨

### DIFF
--- a/components/cli/cmd/cellery/cellery.go
+++ b/components/cli/cmd/cellery/cellery.go
@@ -31,7 +31,7 @@ import (
 
 func newCliCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "cellery [OPTIONS] COMMAND [ARG...]",
+		Use:           "cellery [OPTIONS] COMMAND [ARG]",
 		Short:         "Manage immutable cell based applications",
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -57,6 +57,7 @@ func newCliCommand() *cobra.Command {
 		newPullCommand(),
 		newSetupCommand(),
 		newExtractResourcesCommand(),
+		newListFilesCommand(),
 	)
 	return cmd
 }

--- a/components/cli/cmd/cellery/cellery.go
+++ b/components/cli/cmd/cellery/cellery.go
@@ -56,6 +56,7 @@ func newCliCommand() *cobra.Command {
 		newPushCommand(),
 		newPullCommand(),
 		newSetupCommand(),
+		newExtractResourcesCommand(),
 	)
 	return cmd
 }

--- a/components/cli/cmd/cellery/extract_resources.go
+++ b/components/cli/cmd/cellery/extract_resources.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cellery-io/sdk/components/cli/pkg/commands"
+)
+
+func newExtractResourcesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "extract-resources <organization>/<image_name>:<version> <output_directory>",
+		Short: "Extract the resource files of a pulled image to the provided location",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 2 {
+				return commands.RunExtractResources(args[0], args[1])
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/components/cli/cmd/cellery/list_files.go
+++ b/components/cli/cmd/cellery/list_files.go
@@ -24,24 +24,25 @@ import (
 	"github.com/cellery-io/sdk/components/cli/pkg/commands"
 )
 
-// newExtractResourcesCommand creates a command which can be invoked to extract the cell
-// image resources to a specific directory.
-func newExtractResourcesCommand() *cobra.Command {
+// newListFilesCommand creates a command which can be invoked to list the files (directory structure) of a cell images.
+func newListFilesCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "extract-resources [CELL_IMAGE] [OUTPUT_DIR]",
-		Short: "Extract the resource files of a pulled image to the provided location",
+		Use:   "list-files [CELL_IMAGE]",
+		Short: "List the files in the cell image",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 2 {
+			if len(args) != 1 {
 				cmd.Help()
 				return nil
 			}
-			err := commands.RunExtractResources(args[0], args[1])
+			cellImage = args[0]
+			err := commands.RunListFiles(cellImage)
 			if err != nil {
 				cmd.Help()
 				return err
 			}
 			return nil
 		},
+		Example: "  cellery list-files cellery-samples/hello-world:1.0.0",
 	}
 	return cmd
 }

--- a/components/cli/pkg/commands/apis.go
+++ b/components/cli/pkg/commands/apis.go
@@ -51,13 +51,11 @@ func RunApis(cellName string) error {
 	}()
 	err := cmd.Start()
 	if err != nil {
-		fmt.Printf("Error in executing cellery apis: %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching APIs", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Cellery apis finished with error: \x1b[0m %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching APIs", err)
 	}
 
 	jsonOutput := &util.Gateway{}

--- a/components/cli/pkg/commands/build.go
+++ b/components/cli/pkg/commands/build.go
@@ -75,10 +75,9 @@ func RunBuild(tag string, fileName string) error {
 	cmd.Stderr = &stderr
 	err = cmd.Start()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Error in executing cell build: \x1b[0m %v \n", err)
 		errStr := string(stderr.Bytes())
 		fmt.Printf("%s\n", errStr)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while building cell image", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
@@ -87,7 +86,7 @@ func RunBuild(tag string, fileName string) error {
 		fmt.Println("\x1b[31;1m======================\x1b[0m")
 		errStr := string(stderr.Bytes())
 		fmt.Printf("\x1b[31;1m%s\x1b[0m", errStr)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while building cell image", err)
 	}
 
 	outStr := string(stdout.Bytes())

--- a/components/cli/pkg/commands/components.go
+++ b/components/cli/pkg/commands/components.go
@@ -52,13 +52,11 @@ func RunComponents(cellName string) error {
 	}()
 	err := cmd.Start()
 	if err != nil {
-		fmt.Printf("Error in executing cell components: %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching components", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Cell components finished with error: \x1b[0m %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching components", err)
 	}
 
 	jsonOutput := &util.Service{}

--- a/components/cli/pkg/commands/describe.go
+++ b/components/cli/pkg/commands/describe.go
@@ -21,8 +21,9 @@ package commands
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"os/exec"
+
+	"github.com/cellery-io/sdk/components/cli/pkg/util"
 )
 
 func RunDescribe(cellImage string) error {
@@ -43,13 +44,11 @@ func RunDescribe(cellImage string) error {
 	}()
 	err := cmd.Start()
 	if err != nil {
-		fmt.Printf("Error in executing cell describe: %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching cell details", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Cell describe finished with error: \x1b[0m %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching cell details", err)
 	}
 	return nil
 }

--- a/components/cli/pkg/commands/extract_resources.go
+++ b/components/cli/pkg/commands/extract_resources.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cellery-io/sdk/components/cli/pkg/constants"
+	"github.com/cellery-io/sdk/components/cli/pkg/util"
+)
+
+// RunExtractResources extracts the cell image zip file and copies the resources folder to the provided path
+func RunExtractResources(cellImage string, outputPath string) error {
+	parsedCellImage, err := util.ParseImageTag(cellImage)
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while parsing cell image", err)
+	}
+
+	repoLocation := filepath.Join(util.UserHomeDir(), ".cellery", "repo", parsedCellImage.Organization,
+		parsedCellImage.ImageName, parsedCellImage.ImageVersion)
+	imageLocation := filepath.Join(repoLocation, parsedCellImage.ImageName+constants.CELL_IMAGE_EXT)
+
+	// Create temp directory
+	currentTIme := time.Now()
+	timestamp := currentTIme.Format("27065102350415")
+	tempPath := filepath.Join(util.UserHomeDir(), ".cellery", "tmp", timestamp)
+	err = util.CreateDir(tempPath)
+	if err != nil {
+		fmt.Printf("\x1b[31;1m Error while extracting resources from cell image: \x1b[0m %v \n", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = os.RemoveAll(tempPath)
+		if err != nil {
+			fmt.Printf("\x1b[31;1m Error while cleaning up: \x1b[0m %v \n", err)
+			os.Exit(1)
+		}
+	}()
+
+	// Creating the output path (This will do nothing if it already exists)
+	err = util.CreateDir(outputPath)
+	if err != nil {
+		util.ExitWithErrorMessage("Failed to create the output directory", err)
+	}
+
+	err = util.Unzip(imageLocation, tempPath)
+	if err != nil {
+		panic(err)
+	}
+
+	// Copying the image resources to the provided output directory
+	resourcesDir, err := filepath.Abs(filepath.Join(tempPath, "artifacts", "resources"))
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while extracting the image resources", err)
+	}
+	err = util.CopyDir(resourcesDir, outputPath)
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while extracting the image resources", err)
+	}
+
+	_ = os.RemoveAll(tempPath)
+
+	fmt.Print("\nExtracted resources: " + util.Bold(outputPath))
+	util.PrintSuccessMessage(fmt.Sprintf("Successfully extracred cell image resources: %s", util.Bold(cellImage)))
+	return nil
+}

--- a/components/cli/pkg/commands/extract_resources.go
+++ b/components/cli/pkg/commands/extract_resources.go
@@ -45,14 +45,12 @@ func RunExtractResources(cellImage string, outputPath string) error {
 	tempPath := filepath.Join(util.UserHomeDir(), ".cellery", "tmp", timestamp)
 	err = util.CreateDir(tempPath)
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Error while extracting resources from cell image: \x1b[0m %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error while extracting resources from cell image", err)
 	}
 	defer func() {
 		err = os.RemoveAll(tempPath)
 		if err != nil {
-			fmt.Printf("\x1b[31;1m Error while cleaning up: \x1b[0m %v \n", err)
-			os.Exit(1)
+			util.ExitWithErrorMessage("Error while cleaning up", err)
 		}
 	}()
 
@@ -77,9 +75,7 @@ func RunExtractResources(cellImage string, outputPath string) error {
 		util.ExitWithErrorMessage("Error occurred while extracting the image resources", err)
 	}
 
-	_ = os.RemoveAll(tempPath)
-
-	fmt.Print("\nExtracted resources: " + util.Bold(outputPath))
+	fmt.Print("\nExtracted resources: " + util.Bold(filepath.Abs(outputPath)))
 	util.PrintSuccessMessage(fmt.Sprintf("Successfully extracred cell image resources: %s", util.Bold(cellImage)))
 	return nil
 }

--- a/components/cli/pkg/commands/init.go
+++ b/components/cli/pkg/commands/init.go
@@ -94,8 +94,7 @@ func RunInit() error {
 
 	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
-		fmt.Println("Error in getting current directory location: " + err.Error())
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error in getting current directory location", err)
 	}
 
 	if _, err := os.Stat(dir + "/" + projectName); os.IsNotExist(err) {
@@ -105,8 +104,7 @@ func RunInit() error {
 
 	balFile, err := os.Create(projectPath + "/" + projectName + ".bal")
 	if err != nil {
-		fmt.Println("Error in creating Ballerina File: " + err.Error())
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error in creating Ballerina File", err)
 	}
 	defer balFile.Close()
 	balW := bufio.NewWriter(balFile)

--- a/components/cli/pkg/commands/list_files.go
+++ b/components/cli/pkg/commands/list_files.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package commands
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/cellery-io/sdk/components/cli/pkg/constants"
+	"github.com/cellery-io/sdk/components/cli/pkg/util"
+)
+
+// RunListFiles extracts the cell image and lists the files in the cell image
+func RunListFiles(cellImage string) error {
+	parsedCellImage, err := util.ParseImageTag(cellImage)
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while parsing cell image", err)
+	}
+	cellImageFile := filepath.Join(util.UserHomeDir(), ".cellery", "repo", parsedCellImage.Organization,
+		parsedCellImage.ImageName, parsedCellImage.ImageVersion, parsedCellImage.ImageName+constants.CELL_IMAGE_EXT)
+
+	// Create temp directory
+	currentTime := time.Now()
+	timestamp := currentTime.Format("27065102350415")
+	tempPath := filepath.Join(util.UserHomeDir(), ".cellery", "tmp", timestamp)
+	err = util.CreateDir(tempPath)
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while reading the cell image", err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempPath)
+		if err != nil {
+			util.ExitWithErrorMessage("Error while cleaning up", err)
+		}
+	}()
+
+	// Unzipping Cellery Image
+	err = util.Unzip(cellImageFile, tempPath)
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while reading the cell image", err)
+	}
+
+	// Printing the cell image directory structure
+	fmt.Printf("\n%s\n  │ \n", util.Bold(fmt.Sprintf("%s/%s:%s", parsedCellImage.Organization,
+		parsedCellImage.ImageName, parsedCellImage.ImageVersion)))
+	err = printCellImageDirectory(tempPath, 0, []bool{})
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while printing the cell image files", err)
+	}
+	fmt.Println()
+
+	return nil
+}
+
+func printCellImageDirectory(dir string, nestingLevel int, ancestorBranchPrintRequirement []bool) error {
+	fds, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for i, fd := range fds {
+		//fmt.Printf("%d %d\n", nestingLevel, i)
+		fileName := fd.Name()
+
+		for j := 0; j < nestingLevel; j++ {
+			if ancestorBranchPrintRequirement[j] {
+				fmt.Printf("  │ ")
+			} else {
+				fmt.Printf("    ")
+			}
+		}
+
+		if i == len(fds)-1 {
+			fmt.Print("  └")
+		} else {
+			fmt.Print("  ├")
+		}
+		fmt.Printf("──%s\n", fileName)
+
+		if fd.IsDir() {
+			err = printCellImageDirectory(path.Join(dir, fileName), nestingLevel+1,
+				append(ancestorBranchPrintRequirement, i != len(fds)-1))
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/components/cli/pkg/commands/logs.go
+++ b/components/cli/pkg/commands/logs.go
@@ -21,10 +21,10 @@ package commands
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"os/exec"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/constants"
+	"github.com/cellery-io/sdk/components/cli/pkg/util"
 )
 
 func RunLogs(cellName, componentName string) error {
@@ -57,13 +57,11 @@ func executeLogsCommand(cmd *exec.Cmd, cellName, componentName string) error {
 	}()
 	err := cmd.Start()
 	if err != nil {
-		fmt.Printf("Error in executing cell logs: %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching logs", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Cell logs finished with error: \x1b[0m %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching logs", err)
 	}
 	if output == "" {
 		if componentName == "" {

--- a/components/cli/pkg/commands/ps.go
+++ b/components/cli/pkg/commands/ps.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/cellery-io/sdk/components/cli/pkg/util"
 )
 
 func RunPs() error {
@@ -46,13 +48,11 @@ func RunPs() error {
 	}()
 	err := cmd.Start()
 	if err != nil {
-		fmt.Printf("Error in executing cell ps: %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching the running cell data", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Cell ps finished with error: \x1b[0m %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching the running cell data", err)
 	}
 	return nil
 }

--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -38,12 +38,12 @@ func RunRun(cellImageTag string) error {
 
 	repoLocation := filepath.Join(util.UserHomeDir(), ".cellery", "repo", parsedCellImage.Organization,
 		parsedCellImage.ImageName, parsedCellImage.ImageVersion)
-	fmt.Printf("Running cell image: %s ...\n", util.Bold(cellImageTag))
+	fmt.Printf("Running cell image: %s\n", util.Bold(cellImageTag))
 	zipLocation := filepath.Join(repoLocation, parsedCellImage.ImageName+constants.CELL_IMAGE_EXT)
 
 	if _, err := os.Stat(zipLocation); os.IsNotExist(err) {
 		fmt.Printf("\nUnable to find image %s locally.", cellImageTag)
-		fmt.Printf("\nPulling image: %s ...", cellImageTag)
+		fmt.Printf("\nPulling image: %s", cellImageTag)
 		_ = RunPull(cellImageTag, true)
 	}
 

--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -47,7 +47,7 @@ func RunRun(cellImageTag string) error {
 		_ = RunPull(cellImageTag, true)
 	}
 
-	//create tmp directory
+	// Create tmp directory
 	currentTIme := time.Now()
 	timestamp := currentTIme.Format("20060102150405")
 	tmpPath := filepath.Join(util.UserHomeDir(), ".cellery", "tmp", timestamp)

--- a/components/cli/pkg/commands/status.go
+++ b/components/cli/pkg/commands/status.go
@@ -39,29 +39,25 @@ func RunStatus(cellName string) error {
 
 	outfile, errPrint := os.Create("./out.txt")
 	if errPrint != nil {
-		fmt.Printf("Error in executing cell status: %v \n", errPrint)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching cell status", errPrint)
 	}
 	defer outfile.Close()
 	cmd.Stdout = outfile
 
 	err := cmd.Start()
 	if err != nil {
-		fmt.Printf("Error in executing cell status: %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching cell status", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Cell status finished with error: \x1b[0m %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching cell status", err)
 	}
 
 	outputByteArray, err := ioutil.ReadFile("./out.txt")
 	os.Remove("./out.txt")
 
 	if err != nil {
-		fmt.Printf("Error in executing cell status: %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching cell status", err)
 	}
 
 	output = string(outputByteArray)
@@ -104,13 +100,11 @@ func getCellSummary(cellName string) (cellCreationTime, cellStatus string) {
 	}()
 	err := cmd.Start()
 	if err != nil {
-		fmt.Printf("Error in executing cell status: %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching cell status", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Cell status finished with error: \x1b[0m %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while fetching cell status", err)
 	}
 
 	jsonOutput := &util.Cell{}

--- a/components/cli/pkg/commands/stop.go
+++ b/components/cli/pkg/commands/stop.go
@@ -21,8 +21,9 @@ package commands
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"os/exec"
+
+	"github.com/cellery-io/sdk/components/cli/pkg/util"
 )
 
 func RunStop(instanceName string) error {
@@ -47,13 +48,11 @@ func RunStop(instanceName string) error {
 	}()
 	err := cmd.Start()
 	if err != nil {
-		fmt.Printf("Error in executing cellery stop: %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while stopping the cell instance", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Cell stop finished with error: \x1b[0m %v \n", err)
-		os.Exit(1)
+		util.ExitWithErrorMessage("Error occurred while stopping the cell instance", err)
 	}
 	return nil
 }

--- a/components/cli/pkg/util/utils.go
+++ b/components/cli/pkg/util/utils.go
@@ -403,8 +403,7 @@ func GetDuration(startTime time.Time) string {
 func ConvertStringToTime(timeString string) time.Time {
 	convertedTime, err := time.Parse(time.RFC3339, timeString)
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Error parsing time: \x1b[0m %v \n", err)
-		os.Exit(1)
+		ExitWithErrorMessage("Error parsing time", err)
 	}
 	return convertedTime
 }
@@ -695,27 +694,24 @@ func AddImageToBalPath(cellImage *CellImage) {
 		cellImage.ImageVersion, cellImage.ImageName+constants.CELL_IMAGE_EXT)
 
 	// Create temp directory
-	currentTIme := time.Now()
-	timestamp := currentTIme.Format("27065102350415")
+	currentTime := time.Now()
+	timestamp := currentTime.Format("27065102350415")
 	tempPath := filepath.Join(UserHomeDir(), ".cellery", "tmp", timestamp)
 	err := CreateDir(tempPath)
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Error while saving cell image to local repo: \x1b[0m %v \n", err)
-		os.Exit(1)
+		ExitWithErrorMessage("Error while saving cell image to local repo", err)
 	}
 	defer func() {
 		err = os.RemoveAll(tempPath)
 		if err != nil {
-			fmt.Printf("\x1b[31;1m Error while cleaning up: \x1b[0m %v \n", err)
-			os.Exit(1)
+			ExitWithErrorMessage("Error while cleaning up", err)
 		}
 	}()
 
 	// Unzipping Cellery Image
 	err = Unzip(cellImageFile, tempPath)
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Error while saving cell image to local repo: \x1b[0m %v \n", err)
-		os.Exit(1)
+		ExitWithErrorMessage("Error while saving cell image to local repo", err)
 	}
 
 	balRepoDir := filepath.Join(UserHomeDir(), ".ballerina", "repo", cellImage.Organization, cellImage.ImageName,
@@ -724,22 +720,19 @@ func AddImageToBalPath(cellImage *CellImage) {
 	// Cleaning up the old image bal files if it already exists
 	hasOldImage, err := FileExists(balRepoDir)
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Error occurred while removing the old cell image: \x1b[0m %v \n", err)
-		os.Exit(1)
+		ExitWithErrorMessage("Error occurred while removing the old cell image", err)
 	}
 	if hasOldImage {
 		err = os.RemoveAll(balRepoDir)
 		if err != nil {
-			fmt.Printf("\x1b[31;1m Error while cleaning up: \x1b[0m %v \n", err)
-			os.Exit(1)
+			ExitWithErrorMessage("Error while cleaning up", err)
 		}
 	}
 
 	// Creating the .ballerina directory (ballerina cli fails when this directory is not present)
 	err = CreateDir(filepath.Join(tempPath, "artifacts", "bal", ".ballerina"))
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Error occurred while installing cell reference: \x1b[0m %v \n", err)
-		os.Exit(1)
+		ExitWithErrorMessage("Error occurred while installing cell reference", err)
 	}
 
 	// Installing the cell reference ballerina module
@@ -758,15 +751,13 @@ func AddImageToBalPath(cellImage *CellImage) {
 	cmd.Stderr = &stderr
 	err = cmd.Start()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Error occurred while installing cell reference: \x1b[0m %v \n", err)
 		errStr := string(stderr.Bytes())
 		fmt.Printf("%s\n", errStr)
-		os.Exit(1)
+		ExitWithErrorMessage("Error occurred while installing cell reference", err)
 	}
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Printf("\x1b[31;1m Error occurred while installing cell reference: \x1b[0m %v \n", err)
-		os.Exit(1)
+		ExitWithErrorMessage("Error occurred while installing cell reference", err)
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Implement the CLI commands for extracting resources in the cell image and listing the files in the cell image.

## Goals
> List resources can be used for examining the files in the cell file. The extract resources command is useful for extracting resources (swagger file, proto file, etc.) from the cell image.

## Approach
> The image is extracted in both commands and the resources are copied or the directory structure is printed based on the command. The extracted content is deleted afterwards.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Ballerina 0.990.0
> JDK 1.8.0_192
> go 1.11 linux/amd64
 
## Learning
> N/A