### PR TITLE
Bug Fix in Push/Pull Commands 🐛

### DIFF
--- a/components/cli/pkg/commands/apis.go
+++ b/components/cli/pkg/commands/apis.go
@@ -66,20 +66,30 @@ func RunApis(cellName string) {
 		fmt.Println(errJson)
 	}
 
-	displayApisTable(jsonOutput.GatewaySpec.Apis, cellName)
+	displayApisTable(jsonOutput.GatewaySpec.HttpApis, cellName)
 }
 
-func displayApisTable(apiArray []util.GatewayApi, cellName string) {
+func displayApisTable(apiArray []util.GatewayHttpApi, cellName string) {
 	var tableData [][]string
 
 	for i := 0; i < len(apiArray); i++ {
 		for j := 0; j < len(apiArray[i].Definitions); j++ {
-			url := cellName + "/" + cellName + "-gateway-service" + "/" + apiArray[i].Context + "/" +
-				strings.Split(apiArray[i].Backend, "/")[2]
+			url := cellName + "--gateway-service"
 
-			if apiArray[i].Definitions[j].Path != "/" {
-				url = url + "/" + apiArray[i].Definitions[j].Path
+			// Add the context of the Cell
+			if !strings.HasPrefix(apiArray[i].Context, "/") {
+				url += "/"
 			}
+			url += apiArray[i].Context
+
+			// Add the path of the API definition
+			if apiArray[i].Definitions[j].Path != "/" {
+				if !strings.HasPrefix(apiArray[i].Definitions[j].Path, "/") {
+					url += "/"
+				}
+				url += apiArray[i].Definitions[j].Path
+			}
+
 			tableRecord := []string{apiArray[i].Context, apiArray[i].Definitions[j].Method, url}
 			tableData = append(tableData, tableRecord)
 		}

--- a/components/cli/pkg/commands/pull.go
+++ b/components/cli/pkg/commands/pull.go
@@ -38,7 +38,7 @@ import (
 func RunPull(cellImage string, silent bool) {
 	err := pullImage(cellImage, "", "", silent)
 	if err != nil {
-		if strings.Contains(err.Error(), "UNAUTHORIZED") {
+		if strings.Contains(err.Error(), "401") {
 			username, password, err := util.RequestCredentials()
 			if err != nil {
 				util.ExitWithErrorMessage("Failed to acquire credentials", err)

--- a/components/cli/pkg/commands/push.go
+++ b/components/cli/pkg/commands/push.go
@@ -44,7 +44,7 @@ import (
 func RunPush(cellImage string) {
 	err := pushImage(cellImage, "", "")
 	if err != nil {
-		if strings.Contains(err.Error(), "UNAUTHORIZED") {
+		if strings.Contains(err.Error(), "401") {
 			username, password, err := util.RequestCredentials()
 			if err != nil {
 				util.ExitWithErrorMessage("Failed to acquire credentials", err)

--- a/components/cli/pkg/util/structs.go
+++ b/components/cli/pkg/util/structs.go
@@ -95,10 +95,10 @@ type Gateway struct {
 }
 
 type GatewaySpec struct {
-	Apis []GatewayApi `json:"apis"`
+	HttpApis []GatewayHttpApi `json:"http"`
 }
 
-type GatewayApi struct {
+type GatewayHttpApi struct {
 	Backend     string              `json:"backend"`
 	Context     string              `json:"context"`
 	Definitions []GatewayDefinition `json:"definitions"`


### PR DESCRIPTION
## Purpose
> Fix few issues in the Push/Pull commands and fix an issue in the apis command.

## Goals
> Fix few minor bugs

## Approach
> The unauthorized check was changed to check for 401 sub-string. The APIs command was updated to not show the duplicate "/"s.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> go version go1.11 linux/amd64
 
## Learning
> N/A